### PR TITLE
Add Dokka for generating Javadoc in Maven publications

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 dependencies {
 	implementation(libs.download)
 	implementation(libs.kotlin.multiplatform)
+	implementation(libs.dokka)
 	implementation(libs.jreleaser.plugin)
 	implementation(libs.android.library)
 

--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `maven-publish`
     id("org.jreleaser")
     signing
+    id("org.jetbrains.dokka")
 }
 
 
@@ -76,9 +77,15 @@ project.centralPortalPublish {
     url = layout.buildDirectory.dir("staging-deploy").get().asFile.toURI()
 }
 
+val javadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+    from(tasks.findByName("dokkaHtml"))
+}
+
 publishing {
     publications {
         withType<MavenPublication> {
+            artifact(javadocJar)
             pom {
                 name.set(project.name)
                 description.set(libraryDescription)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jreleaser = "1.13.1"
 agp = "8.5.2"
 jna = "5.15.0"
 kotest = "6.0.0.M1"
+dokka = "2.0.0"
 
 # Jvm demo
 glfwNative = "0.0.1"
@@ -44,6 +45,7 @@ zip4j = { module = "net.lingala.zip4j:zip4j", version = "2.11.5" }
 download = { module = "de.undercouch.download:de.undercouch.download.gradle.plugin", version.ref = "download" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 jreleaser-plugin = { module = "org.jreleaser:org.jreleaser.gradle.plugin", version.ref = "jreleaser" }
+dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 
 [plugins]
 kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }


### PR DESCRIPTION
Integrated the Dokka plugin to generate Javadoc during builds. Updated `publish.gradle.kts` to include a `javadocJar` artifact in Maven publications. Added Dokka dependencies to the build file and library versions catalog.