### PR TITLE
Fix android running issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
     steps:
       - name: install dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install -y libglfw3-dev
+        run: |
+          sudo apt update
+          sudo apt install -y libglfw3-dev
       - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/demo/android/src/androidMain/kotlin/WGPUSurfaceView.kt
+++ b/demo/android/src/androidMain/kotlin/WGPUSurfaceView.kt
@@ -28,7 +28,7 @@ class WGPUSurfaceView : SurfaceView, SurfaceHolder.Callback2 {
     override fun surfaceCreated(surfaceHolder: SurfaceHolder): Unit = memoryScope { scope ->
         val instance = wgpuCreateInstance(null) ?: error("fail to create instance")
         val surface = getSurface(instance, holder)
-        val adapter = getAdapter(surface, instance, WGPUBackendType_Vulkan)
+        val adapter = getAdapter(surface, instance)
         val device = getDevice(adapter)
         val surfaceCapabilities = surfaceCapabilities(surface, adapter)
         configureSurface(device, width, height, surface, surfaceCapabilities.formats.first(), surfaceCapabilities.alphaModes.first(), listOf(surfaceCapabilities.formats.first()))

--- a/demo/common/src/commonMain/kotlin/ext.kt
+++ b/demo/common/src/commonMain/kotlin/ext.kt
@@ -57,19 +57,10 @@ fun configureSurface(
 fun getDevice(adapter: WGPUAdapter): WGPUDevice = memoryScope { scope ->
     var fetchedDevice: WGPUDevice? = null
 
-    val callback = WGPURequestDeviceCallback.allocate(scope, object : WGPURequestDeviceCallback {
-        override fun invoke(
-            status: WGPURequestDeviceStatus,
-            device: WGPUDevice?,
-            message: WGPUStringView?,
-            userdata1: NativeAddress?,
-            userdata2: NativeAddress?
-        ) {
-            if (status != WGPURequestDeviceStatus_Success && device == null) error("fail to get device")
-            fetchedDevice = device
-        }
-
-    })
+    val callback = WGPURequestDeviceCallback.allocate(scope) { status, device, _, _, _ ->
+        if (status != WGPURequestDeviceStatus_Success && device == null) error("fail to get device")
+        fetchedDevice = device
+    }
 
     val callbackInfo = WGPURequestDeviceCallbackInfo.allocate(scope).apply {
         this.callback = callback
@@ -90,19 +81,10 @@ fun getAdapter(surface: WGPUSurface, instance: WGPUInstance, backendType: UInt =
 
     var fetchedAdapter: WGPUAdapter? = null
 
-    val callback = WGPURequestAdapterCallback.allocate(scope, object : WGPURequestAdapterCallback {
-        override fun invoke(
-            status: WGPURequestAdapterStatus,
-            adapter: WGPUAdapter?,
-            message: WGPUStringView?,
-            userdata1: NativeAddress?,
-            userdata2: NativeAddress?
-        ) {
-            if (status != WGPURequestAdapterStatus_Success || adapter == null) error("fail to get adapter")
-            fetchedAdapter = adapter
-        }
-
-    })
+    val callback = WGPURequestAdapterCallback.allocate(scope) { status, adapter, _, _, _ ->
+        if (status != WGPURequestAdapterStatus_Success || adapter == null) error("fail to get adapter")
+        fetchedAdapter = adapter
+    }
 
     callbackInfo.callback = callback
     callbackInfo.userdata2 = scope.bufferOfAddress(callback.handler).handler

--- a/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
+++ b/demo/desktop-and-ios/src/desktopMain/kotlin/main.kt
@@ -37,11 +37,10 @@ fun main() {
     val surface = getSurface(instance, windowHandler)
     val adapter = getAdapter(surface, instance)
     val device = getDevice(adapter)
-    val compatibleFormat = compatibleFormat(surface, adapter)
-    val alphaMode = compatibleAlphaMode(surface, adapter)
-    configureSurface(device, width, height, surface, compatibleFormat, alphaMode)
+    val surfaceCapabilities = surfaceCapabilities(surface, adapter)
+    configureSurface(device, width, height, surface, surfaceCapabilities.formats.first(), surfaceCapabilities.alphaModes.first(), listOf(surfaceCapabilities.formats.first()))
 
-    val scene = HelloTriangleScene(device, compatibleFormat, surface)
+    val scene = HelloTriangleScene(device, surfaceCapabilities.formats.first(), surface)
     scene.initialize()
 
     glfwShowWindow(windowHandler)

--- a/demo/desktop-and-ios/src/jvmMain/kotlin/main.kt
+++ b/demo/desktop-and-ios/src/jvmMain/kotlin/main.kt
@@ -44,11 +44,10 @@ fun main() {
     }
 
     val device = getDevice(adapter)
-    val compatibleFormat = compatibleFormat(surface, adapter)
-    val alphaMode = compatibleAlphaMode(surface, adapter)
-    configureSurface(device, width, height, surface, compatibleFormat, alphaMode)
+    val surfaceCapabilities = surfaceCapabilities(surface, adapter)
+    configureSurface(device, width, height, surface, surfaceCapabilities.formats.first(), surfaceCapabilities.alphaModes.first(), listOf(surfaceCapabilities.formats.first()))
 
-    val scene = HelloTriangleScene(device, compatibleFormat, surface)
+    val scene = HelloTriangleScene(device, surfaceCapabilities.formats.first(), surface)
     scene.initialize()
 
     glfwShowWindow(windowHandler)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kaml = "0.67.0"
 kotlin = "2.1.0"
-wgpu = "v24.0.0.2"
+wgpu = "v24.0.0.0"
 download = "5.6.0"
 jreleaser = "1.13.1"
 agp = "8.7.3"

--- a/wgpu4k-native/build.gradle.kts
+++ b/wgpu4k-native/build.gradle.kts
@@ -268,12 +268,7 @@ java {
     }
 }
 
-fun jniBasePath() = buildNativeResourcesDirectory.resolve("libsDebug")
-
-/*if (Platform.os == Os.MacOs) {
-    tasks.findByName("linkDebugTestMingwX64")?.apply { enabled = false }
-    tasks.findByName("mingwX64Test")?.apply { enabled = false }
-}*/
+fun jniBasePath() = buildNativeResourcesDirectory.resolve("libs")
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()


### PR DESCRIPTION
Simplify callback definitions for device and adapter retrieval. Refactor surface configuration by consolidating surface capabilities logic. Update dependencies, including a correction in the `wgpu` version and adjustment to `jniBasePath`.