### PR TITLE
Remove unnecessary padding from structure layouts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ allprojects {
 	}
 
 	group = "io.ygdrasil"
-	version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "v24.0.0-SNAPSHOT"
+	version = System.getenv("VERSION")?.takeIf { it.isNotBlank() } ?: "v24.0.1-SNAPSHOT"
 }
 
 

--- a/generator/src/main/kotlin/generator/structure/jvm.template.kt
+++ b/generator/src/main/kotlin/generator/structure/jvm.template.kt
@@ -47,7 +47,7 @@ internal fun NativeModel.Structure.toJvmStructure() = templateBuilder {
             newLine()
             // Generate layout
             appendLine("internal val LAYOUT = structLayout(")
-            members.forEach { (name, type, _, _, _, padding) ->
+            members.forEach { (name, type, _, _, _, _, padding) ->
                 padding?.takeIf { it > 0 }
                     ?.let { "\tMemoryLayout.paddingLayout($it),"}
                     ?.let(::appendLine)

--- a/wgpu4k-native/src/jvmMain/kotlin/Structures.jvm.kt
+++ b/wgpu4k-native/src/jvmMain/kotlin/Structures.jvm.kt
@@ -58,9 +58,7 @@ actual interface WGPUStringView : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("data"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("length"),
 		).withName("WGPUStringView")
 
@@ -133,23 +131,14 @@ actual interface WGPUAdapterInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("vendor"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("architecture"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("device"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("description"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("backendType"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("adapterType"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("vendorID"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("deviceID"),
 		).withName("WGPUAdapterInfo")
 
@@ -223,15 +212,10 @@ actual interface WGPUBindGroupDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("layout"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("entryCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("entries"),
 		).withName("WGPUBindGroupDescriptor")
 
@@ -306,19 +290,13 @@ actual interface WGPUBindGroupEntry : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("binding"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("buffer"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("offset"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("size"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("sampler"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("textureView"),
 		).withName("WGPUBindGroupEntry")
 
@@ -384,13 +362,9 @@ actual interface WGPUBindGroupLayoutDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("entryCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("entries"),
 		).withName("WGPUBindGroupLayoutDescriptor")
 
@@ -451,13 +425,9 @@ actual interface WGPUBufferBindingLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("type"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("hasDynamicOffset"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("minBindingSize"),
 		).withName("WGPUBufferBindingLayout")
 
@@ -510,9 +480,7 @@ actual interface WGPUSamplerBindingLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("type"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUSamplerBindingLayout")
@@ -570,13 +538,9 @@ actual interface WGPUTextureBindingLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("sampleType"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("viewDimension"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("multisampled"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUTextureBindingLayout")
@@ -638,13 +602,9 @@ actual interface WGPUStorageTextureBindingLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("access"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("viewDimension"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUStorageTextureBindingLayout")
@@ -714,19 +674,13 @@ actual interface WGPUBindGroupLayoutEntry : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("binding"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("visibility"),
-			MemoryLayout.paddingLayout(24),
 			WGPUBufferBindingLayout.LAYOUT.withName("buffer"),
-			MemoryLayout.paddingLayout(16),
 			WGPUSamplerBindingLayout.LAYOUT.withName("sampler"),
-			MemoryLayout.paddingLayout(24),
 			WGPUTextureBindingLayout.LAYOUT.withName("texture"),
-			MemoryLayout.paddingLayout(24),
 			WGPUStorageTextureBindingLayout.LAYOUT.withName("storageTexture"),
 		).withName("WGPUBindGroupLayoutEntry")
 
@@ -789,11 +743,8 @@ actual interface WGPUBlendComponent : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("operation"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("srcFactor"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("dstFactor"),
 		).withName("WGPUBlendComponent")
 
@@ -842,9 +793,7 @@ actual interface WGPUBlendState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(12),
 			WGPUBlendComponent.LAYOUT.withName("color"),
-			MemoryLayout.paddingLayout(12),
 			WGPUBlendComponent.LAYOUT.withName("alpha"),
 		).withName("WGPUBlendState")
 
@@ -904,15 +853,10 @@ actual interface WGPUBufferDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("usage"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("size"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mappedAtCreation"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUBufferDescriptor")
@@ -976,13 +920,9 @@ actual interface WGPUColor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_DOUBLE.withName("r"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_DOUBLE.withName("g"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_DOUBLE.withName("b"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_DOUBLE.withName("a"),
 		).withName("WGPUColor")
 
@@ -1043,13 +983,10 @@ actual interface WGPUColorTargetState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("blend"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("writeMask"),
 		).withName("WGPUColorTargetState")
 
@@ -1101,9 +1038,7 @@ actual interface WGPUCommandBufferDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPUCommandBufferDescriptor")
 
@@ -1151,9 +1086,7 @@ actual interface WGPUCommandEncoderDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPUCommandEncoderDescriptor")
 
@@ -1206,11 +1139,8 @@ actual interface WGPUCompilationInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("messageCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("messages"),
 		).withName("WGPUCompilationInfo")
 
@@ -1280,19 +1210,13 @@ actual interface WGPUCompilationMessage : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("message"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("type"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("lineNum"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("linePos"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("offset"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("length"),
 		).withName("WGPUCompilationMessage")
 
@@ -1354,11 +1278,8 @@ actual interface WGPUComputePassDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("timestampWrites"),
 		).withName("WGPUComputePassDescriptor")
 
@@ -1413,11 +1334,8 @@ actual interface WGPUComputePassTimestampWrites : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("querySet"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("beginningOfPassWriteIndex"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("endOfPassWriteIndex"),
 		).withName("WGPUComputePassTimestampWrites")
 
@@ -1479,15 +1397,10 @@ actual interface WGPUProgrammableStageDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("module"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("entryPoint"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("constantCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("constants"),
 		).withName("WGPUProgrammableStageDescriptor")
 
@@ -1548,13 +1461,9 @@ actual interface WGPUComputePipelineDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("layout"),
-			MemoryLayout.paddingLayout(48),
 			WGPUProgrammableStageDescriptor.LAYOUT.withName("compute"),
 		).withName("WGPUComputePipelineDescriptor")
 
@@ -1610,11 +1519,8 @@ actual interface WGPUConstantEntry : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("key"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_DOUBLE.withName("value"),
 		).withName("WGPUConstantEntry")
 
@@ -1673,13 +1579,9 @@ actual interface WGPUStencilFaceState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("compare"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("failOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthFailOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("passOp"),
 		).withName("WGPUStencilFaceState")
 
@@ -1766,27 +1668,16 @@ actual interface WGPUDepthStencilState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthWriteEnabled"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthCompare"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStencilFaceState.LAYOUT.withName("stencilFront"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStencilFaceState.LAYOUT.withName("stencilBack"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilReadMask"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilWriteMask"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthBias"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_FLOAT.withName("depthBiasSlopeScale"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_FLOAT.withName("depthBiasClamp"),
 		).withName("WGPUDepthStencilState")
 
@@ -1852,9 +1743,7 @@ actual interface WGPUQueueDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPUQueueDescriptor")
 
@@ -1915,15 +1804,11 @@ actual interface WGPUDeviceLostCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUDeviceLostCallbackInfo")
 
@@ -1986,13 +1871,9 @@ actual interface WGPUUncapturedErrorCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUUncapturedErrorCallbackInfo")
 
@@ -2065,21 +1946,13 @@ actual interface WGPUDeviceDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("requiredFeatureCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("requiredFeatures"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("requiredLimits"),
-			MemoryLayout.paddingLayout(24),
 			WGPUQueueDescriptor.LAYOUT.withName("defaultQueue"),
-			MemoryLayout.paddingLayout(40),
 			WGPUDeviceLostCallbackInfo.LAYOUT.withName("deviceLostCallbackInfo"),
-			MemoryLayout.paddingLayout(32),
 			WGPUUncapturedErrorCallbackInfo.LAYOUT.withName("uncapturedErrorCallbackInfo"),
 		).withName("WGPUDeviceDescriptor")
 
@@ -2144,11 +2017,8 @@ actual interface WGPUExtent3D : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("width"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("height"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthOrArrayLayers"),
 		).withName("WGPUExtent3D")
 
@@ -2218,19 +2088,12 @@ actual interface WGPUFragmentState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("module"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("entryPoint"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("constantCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("constants"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("targetCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("targets"),
 		).withName("WGPUFragmentState")
 
@@ -2285,7 +2148,6 @@ actual interface WGPUFuture : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("id"),
 		).withName("WGPUFuture")
 
@@ -2331,9 +2193,7 @@ actual interface WGPUFutureWaitInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			WGPUFuture.LAYOUT.withName("future"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("completed"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUFutureWaitInfo")
@@ -2387,11 +2247,9 @@ actual interface WGPUInstanceCapabilities : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("timedWaitAnyEnable"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("timedWaitAnyMaxCount"),
 		).withName("WGPUInstanceCapabilities")
 
@@ -2441,9 +2299,7 @@ actual interface WGPUInstanceDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(24),
 			WGPUInstanceCapabilities.LAYOUT.withName("features"),
 		).withName("WGPUInstanceDescriptor")
 
@@ -2612,69 +2468,38 @@ actual interface WGPULimits : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxTextureDimension1D"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxTextureDimension2D"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxTextureDimension3D"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxTextureArrayLayers"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxBindGroups"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxBindGroupsPlusVertexBuffers"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxBindingsPerBindGroup"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxDynamicUniformBuffersPerPipelineLayout"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxDynamicStorageBuffersPerPipelineLayout"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxSampledTexturesPerShaderStage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxSamplersPerShaderStage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxStorageBuffersPerShaderStage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxStorageTexturesPerShaderStage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxUniformBuffersPerShaderStage"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("maxUniformBufferBindingSize"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("maxStorageBufferBindingSize"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("minUniformBufferOffsetAlignment"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("minStorageBufferOffsetAlignment"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxVertexBuffers"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("maxBufferSize"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxVertexAttributes"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxVertexBufferArrayStride"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxInterStageShaderVariables"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxColorAttachments"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxColorAttachmentBytesPerSample"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeWorkgroupStorageSize"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeInvocationsPerWorkgroup"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeWorkgroupSizeX"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeWorkgroupSizeY"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeWorkgroupSizeZ"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("maxComputeWorkgroupsPerDimension"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPULimits")
@@ -2792,13 +2617,9 @@ actual interface WGPUMultisampleState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("count"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mask"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("alphaToCoverageEnabled"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUMultisampleState")
@@ -2856,11 +2677,8 @@ actual interface WGPUOrigin3D : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("x"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("y"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("z"),
 		).withName("WGPUOrigin3D")
 
@@ -2918,13 +2736,9 @@ actual interface WGPUPipelineLayoutDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("bindGroupLayoutCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("bindGroupLayouts"),
 		).withName("WGPUPipelineLayoutDescriptor")
 
@@ -2993,17 +2807,11 @@ actual interface WGPUPrimitiveState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("topology"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stripIndexFormat"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("frontFace"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("cullMode"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("unclippedDepth"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUPrimitiveState")
@@ -3068,13 +2876,9 @@ actual interface WGPUQuerySetDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("type"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("count"),
 		).withName("WGPUQuerySetDescriptor")
 
@@ -3126,9 +2930,7 @@ actual interface WGPURenderBundleDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPURenderBundleDescriptor")
 
@@ -3200,21 +3002,13 @@ actual interface WGPURenderBundleEncoderDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("colorFormatCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("colorFormats"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthStencilFormat"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("sampleCount"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthReadOnly"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilReadOnly"),
 		).withName("WGPURenderBundleEncoderDescriptor")
 
@@ -3294,19 +3088,13 @@ actual interface WGPURenderPassColorAttachment : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("view"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthSlice"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("resolveTarget"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("loadOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("storeOp"),
-			MemoryLayout.paddingLayout(32),
 			WGPUColor.LAYOUT.withName("clearValue"),
 		).withName("WGPURenderPassColorAttachment")
 
@@ -3393,23 +3181,14 @@ actual interface WGPURenderPassDepthStencilAttachment : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("view"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthLoadOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthStoreOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_FLOAT.withName("depthClearValue"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("depthReadOnly"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilLoadOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilStoreOp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilClearValue"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stencilReadOnly"),
 		).withName("WGPURenderPassDepthStencilAttachment")
 
@@ -3491,19 +3270,12 @@ actual interface WGPURenderPassDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("colorAttachmentCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("colorAttachments"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("depthStencilAttachment"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("occlusionQuerySet"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("timestampWrites"),
 		).withName("WGPURenderPassDescriptor")
 
@@ -3562,9 +3334,7 @@ actual interface WGPUChainedStruct : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("next"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("sType"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUChainedStruct")
@@ -3613,9 +3383,7 @@ actual interface WGPURenderPassMaxDrawCount : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("maxDrawCount"),
 		).withName("WGPURenderPassMaxDrawCount")
 
@@ -3668,11 +3436,8 @@ actual interface WGPURenderPassTimestampWrites : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("querySet"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("beginningOfPassWriteIndex"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("endOfPassWriteIndex"),
 		).withName("WGPURenderPassTimestampWrites")
 
@@ -3742,19 +3507,12 @@ actual interface WGPUVertexState : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("module"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("entryPoint"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("constantCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("constants"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("bufferCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("buffers"),
 		).withName("WGPUVertexState")
 
@@ -3833,21 +3591,13 @@ actual interface WGPURenderPipelineDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("layout"),
-			MemoryLayout.paddingLayout(64),
 			WGPUVertexState.LAYOUT.withName("vertex"),
-			MemoryLayout.paddingLayout(32),
 			WGPUPrimitiveState.LAYOUT.withName("primitive"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("depthStencil"),
-			MemoryLayout.paddingLayout(24),
 			WGPUMultisampleState.LAYOUT.withName("multisample"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("fragment"),
 		).withName("WGPURenderPipelineDescriptor")
 
@@ -3924,17 +3674,11 @@ actual interface WGPURequestAdapterOptions : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("featureLevel"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("powerPreference"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("forceFallbackAdapter"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("backendType"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("compatibleSurface"),
 		).withName("WGPURequestAdapterOptions")
 
@@ -4030,29 +3774,17 @@ actual interface WGPUSamplerDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("addressModeU"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("addressModeV"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("addressModeW"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("magFilter"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("minFilter"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mipmapFilter"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_FLOAT.withName("lodMinClamp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_FLOAT.withName("lodMaxClamp"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("compare"),
-			MemoryLayout.paddingLayout(2),
 			ffi.C_SHORT.withName("maxAnisotropy"),
 			MemoryLayout.paddingLayout(6)
 		).withName("WGPUSamplerDescriptor")
@@ -4121,9 +3853,7 @@ actual interface WGPUShaderModuleDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPUShaderModuleDescriptor")
 
@@ -4175,11 +3905,9 @@ actual interface WGPUShaderSourceSPIRV : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("codeSize"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("code"),
 		).withName("WGPUShaderSourceSPIRV")
 
@@ -4228,9 +3956,7 @@ actual interface WGPUShaderSourceWGSL : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("code"),
 		).withName("WGPUShaderSourceWGSL")
 
@@ -4279,9 +4005,7 @@ actual interface WGPUSupportedFeatures : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("featureCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("features"),
 		).withName("WGPUSupportedFeatures")
 
@@ -4330,9 +4054,7 @@ actual interface WGPUSupportedWGSLLanguageFeatures : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("featureCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("features"),
 		).withName("WGPUSupportedWGSLLanguageFeatures")
 
@@ -4405,21 +4127,13 @@ actual interface WGPUSurfaceCapabilities : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("usages"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("formatCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("formats"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("presentModeCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("presentModes"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("alphaModeCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("alphaModes"),
 		).withName("WGPUSurfaceCapabilities")
 
@@ -4512,25 +4226,16 @@ actual interface WGPUSurfaceConfiguration : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("device"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("usage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("width"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("height"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("viewFormatCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("viewFormats"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("alphaMode"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("presentMode"),
 		).withName("WGPUSurfaceConfiguration")
 
@@ -4594,9 +4299,7 @@ actual interface WGPUSurfaceDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
 		).withName("WGPUSurfaceDescriptor")
 
@@ -4644,9 +4347,7 @@ actual interface WGPUSurfaceSourceAndroidNativeWindow : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("window"),
 		).withName("WGPUSurfaceSourceAndroidNativeWindow")
 
@@ -4694,9 +4395,7 @@ actual interface WGPUSurfaceSourceMetalLayer : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("layer"),
 		).withName("WGPUSurfaceSourceMetalLayer")
 
@@ -4748,11 +4447,8 @@ actual interface WGPUSurfaceSourceWaylandSurface : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("display"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("surface"),
 		).withName("WGPUSurfaceSourceWaylandSurface")
 
@@ -4806,11 +4502,8 @@ actual interface WGPUSurfaceSourceWindowsHWND : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("hinstance"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("hwnd"),
 		).withName("WGPUSurfaceSourceWindowsHWND")
 
@@ -4864,11 +4557,8 @@ actual interface WGPUSurfaceSourceXCBWindow : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("connection"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("window"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUSurfaceSourceXCBWindow")
@@ -4923,11 +4613,8 @@ actual interface WGPUSurfaceSourceXlibWindow : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("display"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("window"),
 		).withName("WGPUSurfaceSourceXlibWindow")
 
@@ -4982,11 +4669,8 @@ actual interface WGPUSurfaceTexture : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("texture"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("status"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUSurfaceTexture")
@@ -5042,11 +4726,8 @@ actual interface WGPUTexelCopyBufferLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("offset"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("bytesPerRow"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("rowsPerImage"),
 		).withName("WGPUTexelCopyBufferLayout")
 
@@ -5096,9 +4777,7 @@ actual interface WGPUTexelCopyBufferInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUTexelCopyBufferLayout.LAYOUT.withName("layout"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("buffer"),
 		).withName("WGPUTexelCopyBufferInfo")
 
@@ -5154,13 +4833,9 @@ actual interface WGPUTexelCopyTextureInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("texture"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mipLevel"),
-			MemoryLayout.paddingLayout(12),
 			WGPUOrigin3D.LAYOUT.withName("origin"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("aspect"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUTexelCopyTextureInfo")
@@ -5244,25 +4919,16 @@ actual interface WGPUTextureDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("usage"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("dimension"),
-			MemoryLayout.paddingLayout(12),
 			WGPUExtent3D.LAYOUT.withName("size"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mipLevelCount"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("sampleCount"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("viewFormatCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("viewFormats"),
 		).withName("WGPUTextureDescriptor")
 
@@ -5358,25 +5024,16 @@ actual interface WGPUTextureViewDescriptor : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("label"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("dimension"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("baseMipLevel"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mipLevelCount"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("baseArrayLayer"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("arrayLayerCount"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("aspect"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("usage"),
 		).withName("WGPUTextureViewDescriptor")
 
@@ -5445,11 +5102,9 @@ actual interface WGPUVertexAttribute : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("format"),
-			MemoryLayout.paddingLayout(8),
-			ffi.C_LONG.withName("offset"),
 			MemoryLayout.paddingLayout(4),
+			ffi.C_LONG.withName("offset"),
 			ffi.C_INT.withName("shaderLocation"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUVertexAttribute")
@@ -5509,13 +5164,10 @@ actual interface WGPUVertexBufferLayout : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("stepMode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_LONG.withName("arrayStride"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("attributeCount"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("attributes"),
 		).withName("WGPUVertexBufferLayout")
 
@@ -5585,19 +5237,12 @@ actual interface WGPUInstanceExtras : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(16),
 			WGPUChainedStruct.LAYOUT.withName("chain"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("backends"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_LONG.withName("flags"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("dx12ShaderCompiler"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("gles3MinorVersion"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("dxilPath"),
-			MemoryLayout.paddingLayout(16),
 			WGPUStringView.LAYOUT.withName("dxcPath"),
 		).withName("WGPUInstanceExtras")
 
@@ -5656,9 +5301,7 @@ actual interface WGPUChainedStructOut : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("next"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("sType"),
 			MemoryLayout.paddingLayout(4)
 		).withName("WGPUChainedStructOut")
@@ -5720,15 +5363,11 @@ actual interface WGPUBufferMapCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUBufferMapCallbackInfo")
 
@@ -5795,15 +5434,11 @@ actual interface WGPUCompilationInfoCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUCompilationInfoCallbackInfo")
 
@@ -5870,15 +5505,11 @@ actual interface WGPUCreateComputePipelineAsyncCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUCreateComputePipelineAsyncCallbackInfo")
 
@@ -5945,15 +5576,11 @@ actual interface WGPUCreateRenderPipelineAsyncCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUCreateRenderPipelineAsyncCallbackInfo")
 
@@ -6020,15 +5647,11 @@ actual interface WGPUPopErrorScopeCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUPopErrorScopeCallbackInfo")
 
@@ -6095,15 +5718,11 @@ actual interface WGPUQueueWorkDoneCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPUQueueWorkDoneCallbackInfo")
 
@@ -6170,15 +5789,11 @@ actual interface WGPURequestAdapterCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPURequestAdapterCallbackInfo")
 
@@ -6245,15 +5860,11 @@ actual interface WGPURequestDeviceCallbackInfo : CStructure {
 		}
 
 		internal val LAYOUT = structLayout(
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("nextInChain"),
-			MemoryLayout.paddingLayout(4),
 			ffi.C_INT.withName("mode"),
-			MemoryLayout.paddingLayout(8),
+			MemoryLayout.paddingLayout(4),
 			ffi.C_POINTER.withName("callback"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata1"),
-			MemoryLayout.paddingLayout(8),
 			ffi.C_POINTER.withName("userdata2"),
 		).withName("WGPURequestDeviceCallbackInfo")
 


### PR DESCRIPTION
This commit eliminates redundant `MemoryLayout.paddingLayout` entries across various structure definitions. This cleanup reduces clutter and improves code readability while maintaining the integrity of the layout definitions.