### PR TITLE
Support Wayland in Linux surface creation on demo project

### DIFF
--- a/demo/common/src/commonMain/kotlin/ext.kt
+++ b/demo/common/src/commonMain/kotlin/ext.kt
@@ -147,3 +147,16 @@ fun getSurfaceFromWindows(instance: WGPUInstance, hinstance: NativeAddress, hwnd
 
     return wgpuInstanceCreateSurface(instance, surfaceDescriptor)
 }
+
+fun getSurfaceFromWaylandWindow(instance: WGPUInstance, display: NativeAddress, surface: NativeAddress): WGPUSurface? = memoryScope { scope ->
+
+    val surfaceDescriptor = WGPUSurfaceDescriptor.allocate(scope).apply {
+        nextInChain = WGPUSurfaceSourceWaylandSurface.allocate(scope).apply {
+            chain.sType = WGPUSType_SurfaceSourceWaylandSurface
+            this.display = display
+            this.surface = surface
+        }.handler
+    }
+
+    return wgpuInstanceCreateSurface(instance, surfaceDescriptor)
+}


### PR DESCRIPTION
Add functionality to handle Wayland alongside X11 for Linux platforms in surface creation. Modified the logic to check for Wayland windows and added a helper function to create surfaces using Wayland display and window addresses. This ensures compatibility with both X11 and Wayland environments.